### PR TITLE
Tweaked waterways' widths

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -375,12 +375,21 @@ node[traffic_calming=bump] {
 
 /* Waterways */	
 
-way[waterway=river], 
+way[waterway=river]
+ {
+    z-index: 8;
+    color: #3434ff;
+    width: 3.5;
+    text:auto;
+    text-color: #3434ff;
+    font-size:9;
+    text-position: line;
+    text-offset: 7;}
 way[waterway=canal], 
 way[waterway=stream] {
     z-index: 5;
     color: #3434ff;
-    width: 2;
+    width: 1.5;
     text:auto;
     text-color: #3434ff;
     font-size:9;


### PR DESCRIPTION
rivers, streams, and canals were previously displayed with the same width. This pull increases the river width, slightly decreases the streams and canals' widths. 
