### PR TITLE
fix paths from ./icons to icons/

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -3,7 +3,7 @@ Humanatirian Data Model, derived from Potlatch2 style.
 */
 meta {
     title: "HDM";
-    icon: "/icons/hot_small.png";
+    icon: "icons/hot_small.png";
     description: "Humanitarian Data Model focused style.";
     version: "0.0.1";
     author: "HOT team";
@@ -628,7 +628,7 @@ node {
     text-anchor-vertical: below;
 }
 node[name] {
-    icon-image: "/icons/poi.png";
+    icon-image: "icons/poi.png";
     text: auto;
 }
 
@@ -750,7 +750,7 @@ node|z18-[amenity] {
     text-offset:0;
 }
 node[amenity=school] {
-    icon-image: "/icons/school.png";
+    icon-image: "icons/school.png";
 }
 area[amenity=school]:closed {
     color: yellow;
@@ -759,7 +759,7 @@ area[amenity=school]:closed {
     prop_area_small_name : 1;
 }
 node[amenity=university] {
-    icon-image: "/icons/university.png";
+    icon-image: "icons/university.png";
 }
 node[amenity=library] {
     icon-image: "icons/library.png";
@@ -781,7 +781,7 @@ node[amenity=pub] {
     icon-image: "icons/pub.png";
 }
 node[amenity=restaurant] {
-    icon-image: "/icons/restaurant.png";
+    icon-image: "icons/restaurant.png";
 }
 node[amenity=clinic],
 node[amenity=hospital] {
@@ -1555,7 +1555,7 @@ node[amenity=courthouse] {
     icon-image: "icons/courthouse.png";
 }
 node[highway=street_lamp] {
-    icon-image: "/icons/streetlamp.png";
+    icon-image: "icons/streetlamp.png";
 }
 node[office] {
     text: auto;
@@ -1564,8 +1564,8 @@ node[office] {
     text-position: center;
 }
 node[office=ngo] {
-    icon-image: "/icons/ngo.png";
+    icon-image: "icons/ngo.png";
 }
 node[office=government] {
-    icon-image: "/icons/government.png";
+    icon-image: "icons/government.png";
 }


### PR DESCRIPTION
Samuel reported that the icons whose paths are "./icons/xxx.png" are not displaying. 

I have confirmed this on a brand new profile in josm, using the ubuntuone link, corrected it,  and have fixed this in this pull. 
