### PR TITLE
street_lamp-18.png image reference fixed in HDM.mapcss

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -1563,7 +1563,7 @@ node[amenity=courthouse] {
     icon-image: "icons/courthouse-18.png";
 }
 node[highway=street_lamp] {
-    icon-image: "icons/streetlamp-18.png";
+    icon-image: "icons/street_lamp-18.png";
 }
 node[office] {
     text: auto;


### PR DESCRIPTION
(from streetlamp-18.png)

The mapcss file was referring to a non-existent image.
