### PR TITLE
Namehalos - Fixes #32

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -1581,12 +1581,6 @@ node[amenity=courthouse] {
 node[highway=street_lamp] {
     icon-image: "icons/streetlamp-18.png";
 }
-node[office] {
-    text: auto;
-    text-halo: #ffffaa;
-    text-halo-radius: 1;
-    text-position: center;
-}
 node[office=ngo] {
     icon-image: "icons/ngo-18.png";
 }


### PR DESCRIPTION
![selection_017](https://f.cloud.github.com/assets/955351/943977/e5f40956-0289-11e3-9839-92a3f7021000.png)

As @severinmenard reported in #32 and in the above picture, it was difficult to see the names of nodes in some contexts, especially if it was darker satellite imagery. I've made several commit to improve and standardize the names displayed including: 
- Changing the typeface from DejaVu, to Open Sans which is used in our CartoCSS rendering. 
- Names [except for places] no longer display on nodes zoom levels less than 15.
- Some of these commits are not new features,   https://github.com/skorasaurus/HDM-JOSM-style/commit/1327c2fc7ae259c8e6a7ea93fa612c6a32692d35#L0R631 - but fixed MapCSS errors 
- Using a halo for all names and scaling the font size based on the zoom level. 

There's a couple more small additions that I'd like to also implement as well, changing the font size for text names of areas based on zoom levels and size of the area. 
- Also, apply the name styling to tags brand and operator . Those tags are displayed for amenity=fuel, bureau_de_change, 

As of JOSM 6129, halos for text are now able to be applied to areas. For those using older versions of JOSM, there's no difference. 

Before these commits:
![namehalos-avant](https://f.cloud.github.com/assets/955351/943997/c4a6f468-028c-11e3-9a8f-df56615d78db.png)

After:
![namehalos-apres](https://f.cloud.github.com/assets/955351/944002/e25fac66-028c-11e3-9f59-fee01c9fb18d.png)
