### PR TITLE
display addr:housenumber at z17+

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -1234,7 +1234,10 @@ node[natural=tree] {
 
 /* Addressing */
 
-node|z19-[addr:housenumber] {
+node|z-16[addr:housenumber] {
+   text: eval("");  
+}
+node|z17-[addr:housenumber] {
     symbol-shape: circle;
     symbol-size: eval((min(length(tag("addr:housenumber")), 3) * 5) + 4);
     symbol-fill-color: white;
@@ -1244,7 +1247,7 @@ node|z19-[addr:housenumber] {
     text-anchor-vertical: center;
     text-offset-y: -1;
 }
-node|z19-[addr:housenumber]::hn_casing {
+node|z17-[addr:housenumber]::hn_casing {
     z-index: -100;
     symbol-shape: circle;
     symbol-size: eval((min(length(tag("addr:housenumber")), 3) * 5) + 8);


### PR DESCRIPTION
Small fix: 

As of now, 
![address-labels-avant](https://f.cloud.github.com/assets/955351/944152/790a6b80-029a-11e3-9a54-0f00ffe0f15d.png)
Address House numbers were being displayed without any styling at zoom 15, as shown: 

With this fix, Address numbers only display at zoom 17 or higher (same zoom level as HDM-CartoCSS). 
I realize that we should only match the styling of the HDM-CartoCSS where it's appropriate and in this case, it is appropriate. 

After, with this pull request:
![address-numbers-apres](https://f.cloud.github.com/assets/955351/944165/29f909b0-029b-11e3-8f6a-ffcdce065772.png)
