### PR TITLE
use default text rendering rules for historic=* and leisure=sport_centre fix #42

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -1044,30 +1044,18 @@ node[historic=battlefield] {
 }
 node[historic=castle] {
     icon-image: "icons/tourist_castle.n.16.png";
-    text-offset:0;
-    text: auto;
-    font-size: 10;
     z-index: 20;
 }
 node[historic=memorial] {
     icon-image: "icons/tourist_memorial.n.16.png";
-    text-offset:0;
-    text: auto;
-    font-size: 10;
     z-index: 20;
 }
 node[historic=monument] {
     icon-image: "icons/tourist_monument.n.16.png";
-    text-offset:0;
-    text: auto;
-    font-size: 10;
     z-index: 20;
 }
 node[tourism=museum] {
     icon-image: "icons/tourist_museum.n.16.png";
-    text-offset:0;
-    text: auto;
-    font-size: 10;
     z-index: 20;
 }
 node[tourism=information] {
@@ -1188,10 +1176,6 @@ node[leisure=playground] {
 }
 node[leisure=sports_centre] {
     icon-image: "icons/sport_leisure_centre.n.16.png";
-    z-index: 20;
-    text-offset:0;
-    text: auto;
-    font-size: 10;
     z-index: 20;
 }
 node[man_made=survey_point] {


### PR DESCRIPTION
Fixing issue #42. In current master, the names of historic=\* and leisure=sport_centre would display at high zoom levels and not use our default node naming rules, as shown in example: 
![selection_025](https://f.cloud.github.com/assets/955351/981275/fad3e2ca-0756-11e3-8589-29ba1d211e36.png)

There's a couple other instances of this occurring, with operator= and capacity= tags. I'll issue those up and write fixes for them in different branches. 
