### PR TITLE
lower opacity of landuse=residential

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -1294,7 +1294,7 @@ area[landuse=residential]:closed        {
     color: #EB6D69;
     width: 2;
     fill-color: #eeece1;
-    fill-opacity: 0.6;
+    fill-opacity: 0.05;
 }
 area[landuse=retail]:closed             {
     color: #cc2222;


### PR DESCRIPTION
This is a must fix before we encourage people to use the master zip in github.

Right now, the master on github looks like the following: 
![selection_027](https://f.cloud.github.com/assets/955351/981326/34b79d8e-075b-11e3-9194-d3a84b50c57c.png)

I lowered the opacity of the landuse=residential in this pull request and this is how it looks: 
![selection_026](https://f.cloud.github.com/assets/955351/981340/fb98aa50-075c-11e3-9a25-9c308d508e7e.png)

This problem does not happen in the ubuntuone zip which looks like: 
![selection_028](https://f.cloud.github.com/assets/955351/981356/2e1aab0e-075d-11e3-8ddb-a03fa7904d9b.png)

This bug was likely introduced when I changed the color of the landuse=residential to be different from the building=yes color (if you want me to, I can bisect it to see exactly where this bug started). 
