### PR TITLE
Add default text styling for building and landuse - fix #50

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -210,25 +210,29 @@ way[highway=bridleway] {
     color: #996644;
     width: 2;
     dashes: 4, 2, 2, 2;
-    prop_path : 1;}
+    prop_path : 1;
+}
 way[highway=track] {
     z-index: 5;
     color: #996644;
     width: 2;
     dashes: 4, 2;
-    prop_path : 1;}
+    prop_path : 1;
+}
 way[highway=path] {
     z-index: 5;
     color: #c0a56e;
     width: 2;
     dashes: 2, 2;
-    prop_path : 1;}
+    prop_path : 1;
+}
 way[highway=cycleway] {
     z-index: 5;
     color: blue;
     width: 2;
     dashes: 4, 2;
-    prop_path : 1;}
+    prop_path : 1;
+}
 way[is_prop_set("prop_path")] {
     z-index: 5;
     text: auto;
@@ -253,7 +257,8 @@ way[highway=construction] {
     dashes: 8, 4;
     casing-color: #0000aa;
     casing-width: 1;
-    casing-dashes: 8,4;}
+    casing-dashes: 8,4;
+}
 
 /* Railways */
 
@@ -384,7 +389,8 @@ way[waterway=river]
     text-color: #3434ff;
     font-size:9;
     text-position: line;
-    text-offset: 7;}
+    text-offset: 7;
+}
 way[waterway=canal], 
 way[waterway=stream] {
     z-index: 5;
@@ -394,29 +400,34 @@ way[waterway=stream] {
     text-color: #3434ff;
     font-size:9;
     text-position: line;
-    text-offset: 7;}
-way[waterway=drain]              {z-index: 5;
+    text-offset: 7;
+}
+way[waterway=drain]              {
+    z-index: 5;
     color: #3434ff;
     width: 1;
     text:auto;
     text-color: #3434ff;
     text-position: line;
-    text-offset: 3;}
-way[waterway][tunnel=yes]          {z-index: 5;
-    dashes: 8,4;}
-way[waterway][intermittent=yes]  {z-index: 5;
+    text-offset: 3;
+}
+way[waterway][tunnel=yes]          {
+    z-index: 5;
+    dashes: 8,4;
+}
+way[waterway][intermittent=yes]  {
+    z-index: 5;
     color: #1B00FD;
     opacity: 0.26; }
 
 /* Aeroways */
 
-way[aeroway=aerodrome]:closed
- {
+way[aeroway=aerodrome]:closed {
     z-index: 3;
     color: #bb44bb;
     width: 3;
     casing-color: #660660;
-     casing-width: 1;
+    casing-width: 1;
  }
 way|z-15[aeroway=aerodrome]:closed
  {
@@ -513,7 +524,8 @@ area[aeroway=apron]:closed {
     color: #cc66cc;
     width: 1;
     fill-color: #ddaadd;
-    fill-opacity: 0.5;}
+    fill-opacity: 0.5;
+}
 
 /* Barriers */
 
@@ -542,26 +554,31 @@ way[power=line] {
     dashes: 12,2;
     casing-color: black;
     casing-width: 2;
-    casing-dashes: 4, 38;}
-way[power=minor_line] {z-index: 5;
+    casing-dashes: 4, 38;
+}
+way[power=minor_line] {
+    z-index: 5;
     color: gray;
     width: 2;
     dashes: 2,4;
     casing-width: 3;
     casing-color: white;
-    casing-dashes: 2,22;}
+    casing-dashes: 2,22;
+}
 area[power=station]:closed {
     color: black;
     width: 2;
     fill-color: #666666;
     fill-opacity: 0.6;
-    small_area : true;}
+    small_area : true;
+}
 area[power=generator]:closed {
     color: black;
     width: 2;
     fill-color: #444444;
     fill-opacity: 0.6;
-    small_area : true;}
+    small_area : true;
+}
 
 /* Leisure */
 
@@ -1246,7 +1263,8 @@ area[natural=beach]:closed              {
     width: 1;
     fill-color: yellow;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 way[natural=coastline]                      {
     z-index: 5;
     color: black;
@@ -1257,6 +1275,7 @@ area[landuse]:closed                    {
     width: 2;
     fill-color: #444444;
     fill-opacity: 0.3;
+    small_area : true;
 }
 area[landuse=residential]:closed        {
     color: #EB6D69;
@@ -1296,19 +1315,22 @@ area[tourism]:closed                    {
     width: 1;
     fill-color: #F7CECE;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 area[historic]:closed, area[ruins]:closed  {
     color: #F7F7DE;
     width: 1;
     fill-color: #F7F7DE;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 area[military]:closed                   {
     color: #D6D6D6;
     width: 1;
     fill-color: #D6D6D6;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 area[building]:closed {
     color: #D58C8C;
     width: 1;
@@ -1319,17 +1341,19 @@ area[building]:closed {
 area[natural=water]:closed,
 area[waterway][waterway!=dam]:closed    {
     color: #3434ff;
-       width: 2;
+    width: 2;
     fill-color: #3434ff;
-       fill-opacity: 0.2;
-    small_area : true;}
+    fill-opacity: 0.2;
+    small_area : true;
+}
 way[waterway=dam]                           {
     z-index: 5;
     color: black;
     width: 1;
     fill-color: #222222;
     fill-opacity: 0.1;
-    small_area : true;}
+    small_area : true;
+}
 area[man_made]:closed                           {
     color: black;
     width: 2;
@@ -1347,39 +1371,45 @@ area[man_made=reservoir_covered]:closed {
 }
 area[landuse=reservoir]:closed          {
     color: #3434ff;
-       width: 2;
+    width: 2;
     fill-color: #3434ff;
-       fill-opacity: 0.2;
-    small_area : true;}
+    fill-opacity: 0.2;
+    small_area : true;
+}
 area[landuse=forest]:closed, area[natural=wood]:closed {
     color: green;
-      width: 2;
+    width: 2;
     fill-color: green;
-      fill-opacity: 0.2;
-    small_area : true;}
+    fill-opacity: 0.2;
+    small_area : true;
+}
 area[leisure=park]:closed              {
     color: #22aa22;
     width: 2;
     fill-color: #44ff44;
     fill-opacity: 0.15;
-    small_area : true;}
+    small_area : true;
+}
 area[leisure=garden]:closed            {
     color: #66ff44;
     width: 1;
     fill-color: #66ff44;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 area[leisure=pitch]:closed                  {
     z-index: 6;
     color: #88bb44;
     width: 2;
     fill-color: #88ff44;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 area[landuse=recreation_ground]:closed  {
     color: green;
     fill-color: green;
-    small_area : true;}
+    small_area : true;
+}
 
 area[amenity]:closed, area[shop]:closed          {
     color: #ADCEB5;
@@ -1390,9 +1420,9 @@ area[amenity]:closed, area[shop]:closed          {
 
 area[amenity=parking]:closed            {
     color: #bbaa66;
-       width: 1;
+    width: 1;
     fill-color: #bbaa66;
-       fill-opacity: 0.2;
+    fill-opacity: 0.2;
 }
 area[amenity=school]:closed {
     color: yellow;
@@ -1403,25 +1433,28 @@ area[amenity=school]:closed {
 
 area[public_transport=pay_scale_area]:closed {
     color: gray;
-       width: 1;
+    width: 1;
     fill-color: gray;
-       fill-opacity: 0.1;
+    fill-opacity: 0.1;
 }
 way[man_made=pier]                          {
     z-index: 4;
     color: #777;
     width: 3;
     casing-color: black;
-    casing-width: 1;}
+    casing-width: 1;
+}
 way[man_made=pier][floating=yes]            {
     z-index: 5;
     dashes: 4,2;
-    casing-color: #444;}
+    casing-color: #444;
+}
 area[leisure=marina]:closed                 {
     color: pink;
     fill-color: pink;
     fill-opacity: 0.4;
-    small_area : true;}
+    small_area : true;
+}
 way[leisure=slipway]                        {
     z-index: 5;
     color: grey;
@@ -1434,14 +1467,16 @@ area[leisure=golf_course]:closed {
     width: 2;
     fill-color: #44ee22;
     fill-opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 way[boundary]                         {
     z-index: 5;
     color: #000066;
     width: 2;
     opacity: 0.6;
     dashes: 24,4, 4, 4;
-    z-index: 4;}
+    z-index: 4;
+}
 /* Perhaps should be filled, on lower zooms. */
 way[boundary=national_park]           {
     z-index: 5;
@@ -1449,21 +1484,24 @@ way[boundary=national_park]           {
     width: 2;
     opacity: 0.6;
     dashes: 24,4, 4, 4;
-    z-index: 4;}
+    z-index: 4;
+}
 way[boundary=protected_area]          {
     z-index: 5;
     color: #447744;
     width: 2;
     opacity: 0.6;
     dashes: 12,4, 4, 4;
-    z-index: 4;}
+    z-index: 4;
+}
 way[boundary=administrative]          {
     z-index: 5;
     color: purple;
     width: 2;
     opacity: 0.2;
     dashes: 24,4;
-    z-index: 4;}
+    z-index: 4;
+}
 way[boundary=administrative][waterway] {
     z-index: 5;
     opacity: 0.8;
@@ -1476,7 +1514,8 @@ area[landuse=cemetery]:closed                       {
     width: 2;
     fill-color: #664466;
     opacity: 0.2;
-    small_area : true;}
+    small_area : true;
+}
 /* Addressing. Nodes with addresses *and* match POIs should have a poi icon, so we put addressing first */
 /* Route relations */
 


### PR DESCRIPTION
added the default text styling rules for landuse= and building=\* 

I also standardized the spacing each selector although I realize that should have been its own branch. 
