### PR TITLE
update icon paths

### DIFF
--- a/HDM.mapcss
+++ b/HDM.mapcss
@@ -19,25 +19,25 @@ node, area {
 }
 
 relation[restriction=no_left_turn] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/no_left_turn.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/no_left_turn.svg";
 }
 relation[restriction=no_right_turn] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/no_right_turn.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/no_right_turn.svg";
 }
 relation[restriction=no_straight_on] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/no_straight_on.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/no_straight_on.svg";
 }
 relation[restriction=no_u_turn] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/no_u_turn.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/no_u_turn.svg";
 }
 relation[restriction=only_left_turn] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/only_left_turn.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/only_left_turn.svg";
 }
 relation[restriction=only_right_turn] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/only_right_turn.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/only_right_turn.svg";
 }
 relation[restriction=only_straight_on] {
-    icon-image: "presets/vehicle/restriction/turn_restrictions/only_straight_on.png";
+    icon-image: "presets/vehicle/restriction/turn_restrictions/only_straight_on.svg";
 }
 
 /****************


### PR DESCRIPTION
In JOSM we reordered a lot icons and replaced some png by svg. This PR fixes the icon paths for this style.
(related [JOSM ticket](https://josm.openstreetmap.de/ticket/13217#comment:8))
